### PR TITLE
Adição de .bash de exemplo de deploy via rest

### DIFF
--- a/deploy_workflow.sh
+++ b/deploy_workflow.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+CAMUNDA_URL=http://localhost:8080
+DEPLOYMENT_NAME='My Deployment'
+
+ curl -X POST \
+    $CAMUNDA_URL/engine-rest/deployment/create \
+    -H 'content-type: multipart/form-data; boundary=----a0b7961d-7e05-4f16-be5e-badafbe91233' \
+    -F deployment-name=$DEPLOYMENT_NAME \
+    -F bpmn=@src/main/resources/growthProcess.bpmn


### PR DESCRIPTION
Este é apenas um exemplo de como o deploy poderá ser realizado no futuro.

Ainda falta:
- definir como será o processo de deploy (como controlaremos as versões dos modelos, como controlamos o que já foi e o que não foi deployado)
- automatizar o deploy no CircleCI
- definir como serão setadas as variáveis (CAMUNDA_URL e DEPLOYMENT_NAME). O primeiro, provavelmente no próprio CircleCI. O segundo, ainda não sei
