### PR TITLE
Configuração inicial do Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,22 @@
+version: 2
+jobs:
+  build:
+    working_directory: ~/bpmn-models
+
+    docker:
+      - image: circleci/openjdk:8-jdk-browsers
+
+    steps:
+      - checkout
+      - restore_cache:
+          key: bpmn-models-{{ checksum "pom.xml" }}
+      - run: mvn dependency:go-offline
+      - save_cache:
+          paths:
+            - ~/.m2
+          key: bpmn-models-{{ checksum "pom.xml" }}
+      - run: mvn clean test
+      - store_test_results:
+          path: target/surefire-reports
+      - store_artifacts:
+          path: target/bpmn-models-SNAPSHOT.jar

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,3 @@ jobs:
             - ~/.m2
           key: bpmn-models-{{ checksum "pom.xml" }}
       - run: mvn clean test
-      - store_test_results:
-          path: target/surefire-reports
-      - store_artifacts:
-          path: target/bpmn-models-SNAPSHOT.jar

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,13 +4,11 @@ jobs:
     working_directory: ~/bpmn-models
 
     docker:
-      - image: circleci/openjdk:8-jdk-browsers
-
+      - image: maven:3.5.4-jdk-7
     steps:
       - checkout
       - restore_cache:
           key: bpmn-models-{{ checksum "pom.xml" }}
-      - run: mvn dependency:go-offline
       - save_cache:
           paths:
             - ~/.m2

--- a/.classpath
+++ b/.classpath
@@ -24,7 +24,7 @@
 			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
+	<classpathentry exported="true" kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM maven:3.5.4-jdk-7
+
+RUN mkdir -p /app
+WORKDIR /app
+
+COPY . /app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '2.1'
+services:
+  app:
+    build: .
+    volumes:
+      - .:/app

--- a/pom.xml
+++ b/pom.xml
@@ -191,6 +191,11 @@
     <finalName>${project.artifactId}</finalName>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.19.1</version>
+      </plugin>
+      <plugin>
         <!-- Deploy to Tomcat using: mvn clean package antrun:run
              Follow the instructions in build.properties.example to make it work!-->
         <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -191,14 +191,6 @@
     <finalName>${project.artifactId}</finalName>
     <plugins>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.22.1</version>
-        <configuration>
-          <printSummary>true</printSummary>
-        </configuration>
-      </plugin>
-      <plugin>
         <!-- Deploy to Tomcat using: mvn clean package antrun:run
              Follow the instructions in build.properties.example to make it work!-->
         <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -194,6 +194,9 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.19.1</version>
+        <configuration>
+          <testFailureIgnore>true</testFailureIgnore>
+        </configuration>
       </plugin>
       <plugin>
         <!-- Deploy to Tomcat using: mvn clean package antrun:run

--- a/pom.xml
+++ b/pom.xml
@@ -18,8 +18,8 @@
     <camunda.version>7.9.0-ee</camunda.version>
     Make sure you also switch to EE repository below
     -->
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.7</maven.compiler.source>
+    <maven.compiler.target>1.7</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <failOnMissingWebXml>false</failOnMissingWebXml>
   </properties>
@@ -193,9 +193,9 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.19.1</version>
+        <version>2.22.1</version>
         <configuration>
-          <testFailureIgnore>true</testFailureIgnore>
+          <printSummary>true</printSummary>
         </configuration>
       </plugin>
       <plugin>

--- a/src/test/java/InMemoryH2Test.java
+++ b/src/test/java/InMemoryH2Test.java
@@ -1,5 +1,3 @@
-package creditas.camunda.demo_test;
-
 import java.sql.SQLException;
 
 import org.apache.ibatis.logging.LogFactory;
@@ -13,7 +11,6 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import static org.camunda.bpm.engine.test.assertions.ProcessEngineTests.*;
-import static org.junit.Assert.*;
 
 /**
  * Test case starting an in-memory database-backed Process Engine.

--- a/src/test/java/auto_refi/growth_process/_201810291438Test.java
+++ b/src/test/java/auto_refi/growth_process/_201810291438Test.java
@@ -1,4 +1,5 @@
 package auto_refi.growth_process;
+
 import static org.junit.Assert.assertEquals;
 
 import java.util.HashMap;
@@ -13,7 +14,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 @Deployment(resources = "./auto_refi/growth_process/201810291438.bpmn")
-public class _201810291438 {
+public class _201810291438Test {
 	  @Rule
 	  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 


### PR DESCRIPTION
Este PR tinha o principal intuito de rodar os testes no CI. Como os testes estavam se comportando de maneira estranha (funcionavam localmente mas não no CI), acabei configurando o docker/docker-compose para igualar os ambientes.

O que foi feito:
- adicionado arquivo de configuração do Circle CI
- alterada versão do Java do projeto de 8 para 7 (https://docs.camunda.org/manual/7.5/introduction/supported-environments/#java-runtime)
- adicionado sufixo `Test` na classe de teste, pois sem isso ela não estava rodando
- move das classes de teste (apenas para melhor organização)
